### PR TITLE
Fixed an binary redistribution issue of boost.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ proj.py
 salvia-git.pyproj
 salvia-git.sln
 test_main.cpp
+PerformanceAnalysis/

--- a/build_all.py
+++ b/build_all.py
@@ -79,7 +79,7 @@ def make_boost(proj):
     
     #Get boost build command
     # Add configs
-    libs = ["test", "wave", "program_options"]
+    libs = ["test", "wave", "program_options", "locale"]
     address_model = 'address-model=%d' % proj.arch().bits()
     options = ["--build-dir=./", "--hash", "link=shared", "runtime-link=shared", "threading=multi", "stage"]
     toolset = proj.toolset()
@@ -306,11 +306,11 @@ def build(proj_props, cleanBuild):
     proj.print_props()
     proj.check()
 
-    # make_bjam(proj)
+    make_bjam(proj)
     # if cleanBuild: clean_all(proj)
-    # make_boost(proj)
-    # config_and_make_freetype(proj)
-    # config_and_make_freeimage(proj)
+    make_boost(proj)
+    config_and_make_freetype(proj)
+    config_and_make_freeimage(proj)
     config_and_make_llvm(proj)
     config_and_make_salvia(proj)
 

--- a/eflib/include/thread_pool/threadpool.h
+++ b/eflib/include/thread_pool/threadpool.h
@@ -1,3 +1,127 @@
 #pragma once
 
 #include "./detail/pool.hpp"
+
+#include <thread>
+#include <vector>
+#include <functional>
+#include <atomic>
+
+#define USE_MY_THREAD_POOL 1
+
+namespace eflib
+{
+#if USE_MY_THREAD_POOL == 1
+	class thread_pool
+	{
+	public:
+		explicit thread_pool(uint32_t thread_count):
+			worker_count_{thread_count},
+			pending_count_{0},
+			terminate_{false}
+		{
+			initialize();
+		}
+
+		template <typename F>
+		void schedule(F&& job)
+		{
+			++pending_count_;
+			{
+				std::unique_lock<std::mutex> lock(queue_mutex_);
+				tasks_.push_back(std::forward<F>(job));
+			}
+			queue_cv_.notify_one();
+		}
+
+		void wait()
+		{
+			while (pending_count_ > 0)
+			{
+				std::this_thread::yield();
+			}
+		}
+
+		void terminate()
+		{
+			{
+				std::unique_lock<std::mutex> lock(queue_mutex_);
+				terminate_ = true;
+			}
+			queue_cv_.notify_all();
+
+			for (auto& worker : workers_)
+			{
+				worker.join();
+			}
+			
+			workers_.clear();
+			tasks_.clear();
+			pending_count_ = 0;
+		}
+
+		~thread_pool()
+		{
+			terminate();
+		}
+
+	private:
+		void initialize()
+		{
+			for (uint32_t i_worker = 0; i_worker < worker_count_; ++i_worker)
+			{
+				workers_.emplace_back(
+					[this]() {thread_func(); }
+				);
+			}
+		}
+
+		void thread_func()
+		{
+			std::function<void()> job;
+
+			for(;;)
+			{
+				{
+					std::unique_lock<std::mutex> lock(queue_mutex_);
+
+					queue_cv_.wait(lock, 
+						[this] {
+							return !tasks_.empty() || terminate_;
+						}
+					);
+
+					if (terminate_)
+					{
+						return;
+					}
+
+					if (!tasks_.empty())
+					{
+						std::swap(job, tasks_.back());
+						tasks_.pop_back();
+					}
+				}
+
+				if (job)
+				{
+					job();
+					--pending_count_;
+				}
+			}
+		}
+
+		bool terminate_;
+		std::mutex queue_mutex_;
+		std::condition_variable queue_cv_;
+
+		uint32_t worker_count_;
+		std::atomic<intptr_t> pending_count_;
+		std::vector<std::thread> workers_;
+		std::vector<std::function<void()>> tasks_;
+	};
+#else
+	using thread_pool = threadpool::pool;
+#endif
+}
+

--- a/salviar/include/texture.h
+++ b/salviar/include/texture.h
@@ -69,6 +69,15 @@ public:
 		}
 		return surface_ptr();
 	}
+
+	surface const* subresource_cptr(size_t index) const
+	{
+		if (max_lod_ <= index && index <= index)
+		{
+			return surfs_[index].get();
+		}
+		return nullptr;
+	}
 	
 	eflib::uint4 size() const
 	{
@@ -77,7 +86,7 @@ public:
 
 	eflib::uint4 size(size_t subresource_index) const
 	{
-		auto subres = subresource(subresource_index);
+		auto subres = subresource_cptr(subresource_index);
 		if (subres)
 		{
 			return eflib::uint4(0, 0, 0, 0);

--- a/salviar/include/thread_pool.h
+++ b/salviar/include/thread_pool.h
@@ -6,6 +6,6 @@
 
 BEGIN_NS_SALVIAR()
 
-eflib::threadpool::pool& global_thread_pool();
+eflib::thread_pool& global_thread_pool();
 
 END_NS_SALVIAR()

--- a/salviar/src/sampler.cpp
+++ b/salviar/src/sampler.cpp
@@ -651,7 +651,7 @@ color_rgba32f sampler::sample_impl(int face, float coordx, float coordy, size_t 
 	if(is_mag)
 	{
 		auto subres_index = compute_cube_subresource(dummy, face_sz, tex_->max_lod() );
-		return sample_surface(*tex_->subresource(subres_index), coordx, coordy, sample, sampler_state_mag);
+		return sample_surface(*tex_->subresource_cptr(subres_index), coordx, coordy, sample, sampler_state_mag);
 	}
 
 	if(desc_.mip_filter == filter_point)
@@ -661,7 +661,7 @@ color_rgba32f sampler::sample_impl(int face, float coordx, float coordy, size_t 
         ml = eflib::clamp(ml, static_cast<int>(tex_->max_lod()), static_cast<int>(tex_->min_lod()));
 
 		auto subres_index = compute_cube_subresource(dummy, face_sz, ml);
-		return sample_surface(*tex_->subresource(subres_index), coordx, coordy, sample, sampler_state_min);
+		return sample_surface(*tex_->subresource_cptr(subres_index), coordx, coordy, sample, sampler_state_min);
 	}
 
 	if(desc_.mip_filter == filter_linear)
@@ -677,8 +677,8 @@ color_rgba32f sampler::sample_impl(int face, float coordx, float coordy, size_t 
 		auto subres_index_lo = compute_cube_subresource(dummy, face_sz, lo_sz);
 		auto subres_index_hi = compute_cube_subresource(dummy, face_sz, hi_sz);
 
-		color_rgba32f c0 = sample_surface(*tex_->subresource(subres_index_lo), coordx, coordy, sample, sampler_state_min);
-		color_rgba32f c1 = sample_surface(*tex_->subresource(subres_index_hi), coordx, coordy, sample, sampler_state_min);
+		color_rgba32f c0 = sample_surface(*tex_->subresource_cptr(subres_index_lo), coordx, coordy, sample, sampler_state_min);
+		color_rgba32f c1 = sample_surface(*tex_->subresource_cptr(subres_index_hi), coordx, coordy, sample, sampler_state_min);
 
 		return lerp(c0, c1, frac);
 	}
@@ -707,10 +707,10 @@ color_rgba32f sampler::sample_impl(int face, float coordx, float coordy, size_t 
 			auto subres_index_lo = compute_cube_subresource(dummy, face_sz, lo_sz);
 			auto subres_index_hi = compute_cube_subresource(dummy, face_sz, hi_sz);
 			color_rgba32f c0 = sample_surface(
-				*tex_->subresource(subres_index_lo), sample_coord_x, sample_coord_y, sample, sampler_state_min
+				*tex_->subresource_cptr(subres_index_lo), sample_coord_x, sample_coord_y, sample, sampler_state_min
 				);
 			color_rgba32f c1 = sample_surface(
-				*tex_->subresource(subres_index_hi), sample_coord_x, sample_coord_y, sample, sampler_state_min
+				*tex_->subresource_cptr(subres_index_hi), sample_coord_x, sample_coord_y, sample, sampler_state_min
 				);
 
 			color += lerp(c0, c1, frac).get_vec4();

--- a/salviar/src/thread_pool.cpp
+++ b/salviar/src/thread_pool.cpp
@@ -9,9 +9,9 @@ using eflib::num_available_threads;
 
 BEGIN_NS_SALVIAR()
 
-eflib::threadpool::pool& global_thread_pool()
+eflib::thread_pool& global_thread_pool()
 {
-	static eflib::threadpool::pool tp(num_available_threads() - 1);
+	static eflib::thread_pool tp(std::thread::hardware_concurrency() - 1);
 	return tp;
 }
 


### PR DESCRIPTION
Use a simpler thread_pool to instead original version. Its performance is a bit higher than original threadpool.
Added subresource_cptr to return raw pointer which don't have atomic operation. It gains performance.