### PR TITLE
Fixed MSVC compilation issues on Windows.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,25 +1,3 @@
-macro(SALVIA_CHECK_BUILD_WITH_UNICODE)
-    if(SALVIA_BUILD_WITH_UNICODE)
-        ADD_DEFINITIONS(
-            -DUNICODE
-            -D_UNICODE
-        )
-    endif ()
-endmacro(SALVIA_CHECK_BUILD_WITH_UNICODE)
-
-macro(SALVIA_GROUP_BY_DIRECTORY root_group prefix sources)
-    foreach(file_path ${${sources}})
-        STRING(REGEX REPLACE ${prefix}/\(.*\) \\1 filterated_file_path ${file_path})
-        STRING(REGEX REPLACE "\(.*\)/.*" \\1 group_name ${filterated_file_path})
-        STRING(COMPARE EQUAL ${filterated_file_path} ${group_name} no_group)
-        STRING(REPLACE "/" "\\" group_name ${group_name})
-        if(no_group)
-            set(group_name "\\")
-        endif(no_group)
-        SOURCE_GROUP( "${root_group}\\${group_name}" FILES ${file_path})
-    endforeach(file_path)
-endmacro(SALVIA_GROUP_BY_DIRECTORY)
-
 # create vcproj.user file for Visual Studio to set debug working directory
 function(SALVIA_CREATE_VCPROJ_USERFILE TARGETNAME)
   if(MSVC)

--- a/eflib/include/eflib/concurrency/thread_pool/detail/pool_core.hpp
+++ b/eflib/include/eflib/concurrency/thread_pool/detail/pool_core.hpp
@@ -63,7 +63,7 @@ public:                                               // Type definitions
   // static_assert(function_traits<task_type()>::arity == 0);
 
   // The task function's result type is required to be void.
-  static_assert(is_void<typename result_of<task_type()>::type>::value);
+  static_assert(is_void<typename invoke_result<task_type()>::type>::value);
 
 private: // Friends
   friend class worker_thread<pool_type>;

--- a/eflib/include/eflib/diagnostics/assert.h
+++ b/eflib/include/eflib/diagnostics/assert.h
@@ -12,8 +12,10 @@
 #define ef_debug_break() __debugbreak()
 #endif
 
-#if !defined(ef_debug_break) && defined(__clang__) && __has_builtin(__builtin_debugtrap)
+#if !defined(ef_debug_break) && defined(__clang__)
+#if __has_builtin(__builtin_debugtrap)
 #define ef_debug_break() __builtin_debugtrap()
+#endif
 #endif
 
 #if !defined(ef_debug_break) && defined(__GNUC__)

--- a/salvia/include/salvia/shader/shader_cbuffer.h
+++ b/salvia/include/salvia/shader/shader_cbuffer.h
@@ -3,6 +3,7 @@
 
 #include <eflib/utility/shared_declaration.h>
 
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>

--- a/salvia/include/salvia/utility/api_symbols.h
+++ b/salvia/include/salvia/utility/api_symbols.h
@@ -2,7 +2,7 @@
 
 #include <eflib/platform/dl_sym_vis.h>
 
-#if defined(salviau_EXPORTS)
+#if defined(salvia_utility_EXPORTS)
 #define SALVIA_UTILITY_API EFLIB_SYM_EXPORT
 #else
 #define SALVIA_UTILITY_API EFLIB_SYM_IMPORT

--- a/salvia/src/core/default_vertex_cache.cpp
+++ b/salvia/src/core/default_vertex_cache.cpp
@@ -22,6 +22,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <execution>
 
 using namespace salvia::shader;
 using namespace eflib;
@@ -142,11 +143,7 @@ public:
 #if !USE_INDEX_RANGE
     // Unique indices
     unique_indices_ = indices_;
-#if defined(EFLIB_MSVC)
-    concurrency::parallel_radixsort(unique_indices_.begin(), unique_indices_.end());
-#else
-    std::sort(unique_indices_.begin(), unique_indices_.end());
-#endif
+    std::sort(std::execution::par, unique_indices_.begin(), unique_indices_.end());
     unique_indices_.erase(std::unique(unique_indices_.begin(), unique_indices_.end()),
                           unique_indices_.end());
 

--- a/salvia/src/utility/CMakeLists.txt
+++ b/salvia/src/utility/CMakeLists.txt
@@ -1,8 +1,8 @@
-file(GLOB_RECURSE HEADER_LIST CONFIGURE_DEPENDS "../../include/salvia/utility" "*.h")
-file(GLOB_RECURSE SOURCE_LIST CONFIGURE_DEPENDS "." "*.cpp")
+file(GLOB_RECURSE HEADER_LIST CONFIGURE_DEPENDS "../../include/salvia/utility/*.h")
+file(GLOB_RECURSE SOURCE_LIST CONFIGURE_DEPENDS "*.cpp" "*.h")
 
-#source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/../../include/salvia/utility" PREFIX "Header Files" FILES ${HEADER_LIST})
-#source_group(TREE "${CMAKE_CURRENT_LIST_DIR}" PREFIX "Source Files" FILES ${SOURCE_LIST})
+source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/../../include/salvia/utility" PREFIX "Header Files" FILES ${HEADER_LIST})
+source_group(TREE "${CMAKE_CURRENT_LIST_DIR}" PREFIX "Source Files" FILES ${SOURCE_LIST})
 
 add_library(salvia_utility SHARED ${HEADER_LIST} ${SOURCE_LIST})
 
@@ -11,7 +11,7 @@ target_link_libraries(salvia_utility
         salvia_ext salvia_core salvia_resource salvia_shader
         eflib fmt::fmt Boost::program_options
         )
-set_target_properties(salvia_utility PROPERTIES FOLDER "Samples")
+set_target_properties(salvia_utility PROPERTIES FOLDER "Salvia")
 
 #install(TARGETS salviau)
 #install(

--- a/sasl/src/codegen/ty_cache.cpp
+++ b/sasl/src/codegen/ty_cache.cpp
@@ -6,12 +6,17 @@
 
 #include <fmt/format.h>
 
+#if __has_include(<boost/unordered/unordered_flat_map.hpp>)
 #include <boost/unordered/unordered_flat_map.hpp>
+#define fast_unordered_map boost::unordered::unordered_flat_map
+#else
+#include <unordered_map>
+#define fast_unordered_map std::unordered_map
+#endif
 
 #include <vector>
 
 using namespace sasl::enums;
-using boost::unordered::unordered_flat_map;
 using std::vector;
 
 namespace sasl::codegen {
@@ -27,9 +32,9 @@ private:
   Type *create_ty(LLVMContext &ctxt, builtin_types bt, abis abi);
   Type *create_abi_ty(LLVMContext &ctxt, builtin_types bt, abis abi);
 
-  unordered_flat_map<LLVMContext *, unordered_flat_map<builtin_types, Type *>>
+  fast_unordered_map<LLVMContext *, fast_unordered_map<builtin_types, Type *>>
       cache[e2i(abis::count)];
-  unordered_flat_map<builtin_types, std::string> ty_name[e2i(abis::count)];
+  fast_unordered_map<builtin_types, std::string> ty_name[e2i(abis::count)];
 };
 
 Type *ty_cache_t::type(LLVMContext &ctxt, builtin_types bt, abis abi) {
@@ -37,8 +42,8 @@ Type *ty_cache_t::type(LLVMContext &ctxt, builtin_types bt, abis abi) {
     return nullptr;
   }
 
-  unordered_flat_map<builtin_types, Type *> &ty_table = cache[static_cast<int>(abi)][&ctxt];
-  unordered_flat_map<builtin_types, Type *>::iterator ty_table_it = ty_table.find(bt);
+  auto &ty_table = cache[static_cast<int>(abi)][&ctxt];
+  auto ty_table_it = ty_table.find(bt);
 
   if (ty_table_it != ty_table.end()) {
     return ty_table_it->second;


### PR DESCRIPTION
Temporary fix for boost < 1.81.0.
Remove unused code.
Replace msvc's concurrency library with std::execution.
Fixed DLL export issues.
Fixed source group issues in Visual Studio.