### PR TITLE
sasl.drivers is now testable.

### DIFF
--- a/cmake/ConfigCompiler.cmake
+++ b/cmake/ConfigCompiler.cmake
@@ -30,3 +30,10 @@ endif(MSVC)
 if(MINGW OR UNIX)
   include(${CMAKE_CURRENT_LIST_DIR}/GCC.cmake)
 endif(MINGW OR UNIX)
+
+function(deploy_dlls target)
+add_custom_command(TARGET ${target} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}>
+  COMMAND_EXPAND_LISTS
+  )
+endfunction()

--- a/sasl/src/drivers/CMakeLists.txt
+++ b/sasl/src/drivers/CMakeLists.txt
@@ -1,14 +1,12 @@
 file(GLOB HEADER_LIST CONFIGURE_DEPENDS "../../include/drivers/*.h")
 file(GLOB SOURCE_LIST CONFIGURE_DEPENDS "*.cpp")
 
-include(CheckCXXCompilerFlag)
-
 # Configure Dynamic Link Driver.
 add_library(sasl_drivers SHARED ${HEADER_LIST} ${SOURCE_LIST})
 # disable compiler error caused by __DATE__ and __TIME__ which is used in Boost.Wave
 target_compile_options_if_applicable(sasl_drivers "-Wno-date-time")
 target_include_directories(sasl_drivers PUBLIC ../../include)
-target_link_libraries( sasl_drivers
+target_link_libraries( sasl_drivers PUBLIC
 	sasl_shims sasl_codegen sasl_semantic sasl_syntax_tree sasl_parser sasl_enums sasl_common eflib
     Boost::wave Boost::program_options
 )

--- a/sasl/src/parser/lexer.cpp
+++ b/sasl/src/parser/lexer.cpp
@@ -90,7 +90,7 @@ public:
 
     // change state
     auto state_translate_key = make_pair(id, splexer_state);
-    if (data->state_translations.contains(state_translate_key) > 0) {
+    if (data->state_translations.contains(state_translate_key)) {
       auto next_state = data->state_translations[state_translate_key];
       splexer_ctxt.set_state_name(next_state.c_str());
     }

--- a/sasl/test/CMakeLists.txt
+++ b/sasl/test/CMakeLists.txt
@@ -1,50 +1,11 @@
-# SALVIA_CHECK_BUILD_WITH_UNICODE()
-
-# function(SASL_TEST_CREATE_VCPROJ_USERFILE TARGETNAME)
-#   if(MSVC)
-#     set(SYSTEM_NAME $ENV{USERDOMAIN})
-#     set(USER_NAME $ENV{USERNAME})
-	
-# 	if(MSVC_VERSION EQUAL 1700)
-#       configure_file(
-# 	  ${SASL_HOME_DIR}/sasl/test/test_resources/vs2012.test.vcxproj.user.in
-# 	  ${CMAKE_CURRENT_BINARY_DIR}/${TARGETNAME}.vcxproj.user
-# 	  @ONLY
-# 	)
-# 	elseif(MSVC_VERSION EQUAL 1800)
-# 	  configure_file(
-# 	    ${SASL_HOME_DIR}/sasl/test/test_resources/vs2013.test.vcxproj.user.in
-# 	    ${CMAKE_CURRENT_BINARY_DIR}/${TARGETNAME}.vcxproj.user
-# 	    @ONLY
-# 	  )
-# 	elseif(MSVC_VERSION GREATER 1920)
-# 		configure_file(
-# 			${SASL_HOME_DIR}/sasl/test/test_resources/vs2019.test.vcxproj.user.in
-# 			${CMAKE_CURRENT_BINARY_DIR}/${TARGETNAME}.vcxproj.user
-# 			@ONLY
-# 	    )
-# 	else()
-# 	  MESSAGE(FATAL_ERROR "Cannot support Microsoft Visual C++ version ${MSVC_VERSION}. Build will be stopped." )
-# 	endif()
-#   endif()
-# endfunction(SASL_TEST_CREATE_VCPROJ_USERFILE)
-
-# ADD_SUBDIRECTORY( repo )
-# ADD_SUBDIRECTORY( abi_test )
-# ADD_SUBDIRECTORY( death_test )
-# ADD_SUBDIRECTORY( jit_test )
-
 set(SOURCE_LIST "")
 
-foreach(comp_name "main" "common" "parser")
+foreach(comp_name "main" "common" "parser" "drivers")
   file(GLOB_RECURSE TMP_SOURCE_LIST CONFIGURE_DEPENDS "./${comp_name}/*.cpp")
   list(APPEND SOURCE_LIST ${TMP_SOURCE_LIST})
 endforeach()
 
-
-source_group(TREE "${CMAKE_CURRENT_LIST_DIR}" PREFIX "Source Files" FILES ${SOURCE_LIST})
-
 add_executable(sasl_test ${SOURCE_LIST})
-target_link_libraries(sasl_test PRIVATE sasl_common eflib GTest::gtest GTest::gtest_main Boost::boost $<$<PLATFORM_ID:UNIX>:dl>)
+target_link_libraries(sasl_test PUBLIC sasl_drivers sasl_common eflib GTest::gtest GTest::gtest_main Boost::boost Boost::program_options $<$<PLATFORM_ID:UNIX>:dl>)
 target_compile_features(sasl_test PUBLIC cxx_std_20)
-
+deploy_dlls(sasl_test)

--- a/sasl/test/drivers/drivers.cpp
+++ b/sasl/test/drivers/drivers.cpp
@@ -1,0 +1,11 @@
+#include <gtest/gtest.h>
+
+#include <sasl/drivers/drivers_api.h>
+
+using namespace sasl::drivers;
+
+TEST(sasl_drivers, create_driver_instance) { 
+  compiler_ptr out;
+  sasl_create_compiler(out);
+  EXPECT_TRUE(out != nullptr);
+}


### PR DESCRIPTION
Dependencies of executable will be copied into folder in build stage.