### PR TITLE
CppLab: Coding style improvement for new parser.

### DIFF
--- a/toolkit/cpplab/CMakeLists.txt
+++ b/toolkit/cpplab/CMakeLists.txt
@@ -7,11 +7,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(fmt CONFIG REQUIRED)
 find_package(GTest CONFIG REQUIRED)
 find_package(nameof CONFIG REQUIRED)
+find_package(range-v3 CONFIG REQUIRED)
 
 function( sample_link_libraries target )
  target_link_libraries(${target} PRIVATE fmt::fmt-header-only)
  target_link_libraries(${target} PRIVATE nameof::nameof)
  target_link_libraries(${target} PRIVATE GTest::gtest GTest::gtest_main)
+ target_link_libraries(${target} PRIVATE range-v3 range-v3-meta range-v3::meta range-v3-concepts)
 endfunction()
 
 file(GLOB sources CONFIGURE_DEPENDS *.cpp *.h)

--- a/toolkit/cpplab/vcpkg.json
+++ b/toolkit/cpplab/vcpkg.json
@@ -4,6 +4,7 @@
     "dependencies": [
       "fmt",
       "gtest",
-      "nameof"
+      "nameof",
+      "range-v3"
     ]
 }


### PR DESCRIPTION
Use `ranges::view::enumerate` to instead for-loop.
Now `parse` could accept a visitor.
Code reformatted.